### PR TITLE
Split CI zkg run into separate test and install steps.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,8 +15,11 @@ package_ci_task:
     cpu: 2
     memory: 12G
 
+  test_script:
+    - zkg test .
+
   install_script:
-    - zkg install --force .
+    - zkg install --force --skiptests .
 
   check_script:
     - zeek -N _Zeek::Spicy

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,6 +25,9 @@ package_ci_task:
     - zeek -N _Zeek::Spicy
     - zeek local
 
+  always:
+      stderr_script: ./ci/show-zkg-stderr
+
 standalone_ci_task:
   timeout_in: 120m
   container:

--- a/ci/show-zkg-stderr
+++ b/ci/show-zkg-stderr
@@ -1,0 +1,9 @@
+#! /bin/sh
+#
+# Gather debug output from zkg
+
+for root in in /root/.zkg /opt/zeek/var/lib/zkg; do # root differs by Zeek version
+    test -d "${root}" && find "${root}" -name zkg.*.stderr -exec 'cat' '{}' ';'
+done
+
+true

--- a/zkg.meta
+++ b/zkg.meta
@@ -2,5 +2,5 @@
 script_dir = plugin/scripts
 plugin_dir = build/plugin
 
-build_command = mkdir -p build && cd build && cmake .. && make -j
-test_command = cd tests && btest -dj
+build_command = mkdir -p build && cd build && cmake .. && make -j 4
+test_command = cd tests && btest -d -j 2


### PR DESCRIPTION
Installing with --force lets it ignore errors.