### PR TITLE
Disable JIT parallelism in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,7 @@
+environment:
+    # Enforce sequential JIT'ing of files for controlled memory usage.
+    HILTI_JIT_SEQUENTIAL: 1
+
 package_ci_task:
   timeout_in: 120m
   container:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,11 +3,11 @@ all: test
 test: test-build
 
 test-build:
-	@btest -j 2 -d
+	@btest -j -d
 
 # Might need to have SPICY_INSTALLATION_DIRECTORY set.
 test-install:
-	@btest -j 2 -d -a installation
+	@btest -j -d -a installation
 
 clean:
 	@rm -f $(DIAG) .btest.failed.dat


### PR DESCRIPTION
This fix is related to zeek/spicy#828.