### PR TITLE
Request less memory for Cirrus CI tasks.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ package_ci_task:
         - ZEEK_LTS: 1
         - ZEEK_VERSION: 4.0.0-0
     cpu: 2
-    memory: 12G
+    memory: 8G
 
   install_spicy_script:
     - curl -o spicy-dev.deb https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_ubuntu20/packages/spicy-dev.deb
@@ -44,7 +44,7 @@ standalone_ci_task:
         - ZEEK_LTS:
         - ZEEK_VERSION: 4.0.0-0
     cpu: 2
-    memory: 12G
+    memory: 8G
 
   install_spicy_script:
     - curl -o spicy-dev.deb https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_ubuntu20/packages/spicy-dev.deb

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,11 +3,11 @@ all: test
 test: test-build
 
 test-build:
-	@btest -j -d
+	@btest -d
 
 # Might need to have SPICY_INSTALLATION_DIRECTORY set.
 test-install:
-	@btest -j -d -a installation
+	@btest -d -a installation
 
 clean:
 	@rm -f $(DIAG) .btest.failed.dat


### PR DESCRIPTION
Since recently Cirrus CI seems to enforce that not more than 4GB of
memory can be requested per cpu. We were requesting more than that for a
long time.

This patch brings the memory requested per cpi in line with what we do
in zeek/spicy, namely we now request 3GB/cpu, which means that we now
request 6GB of memory total matching the cpu=2 request.