### PR TITLE
Build package without parallelism.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -2,7 +2,7 @@
 script_dir = plugin/scripts
 plugin_dir = build/plugin
 
-build_command = mkdir -p build && cd build && cmake .. && make -j 4
-test_command = cd tests && btest -d -j 2
+build_command = mkdir -p build && cd build && cmake .. && make
+test_command = cd tests && btest -d
 
 executables = build/plugin/bin/spicyz


### PR DESCRIPTION
Since building this package is pretty memory intensive, do not assume
that we can build in parallel. Users can override this by setting
`MAKEFLAGS` in the environment, e.g., to build using all CPUs:

    $ MAKEFLAGS="-j$(nproc)" zkg install zeek/spicy-analyzers