### PR TITLE
Make parallel build and test opt-out instead of opt-in.

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -2,7 +2,7 @@
 script_dir = plugin/scripts
 plugin_dir = build/plugin
 
-build_command = mkdir -p build && cd build && cmake .. && make -j 4
-test_command = cd tests && btest -d -j 2
+build_command = mkdir -p build && cd build && cmake .. && make -j "${SPICY_ZKG_PROCESSES:-4}"
+test_command = cd tests && btest -d -j "${SPICY_ZKG_PROCESSES:-2}"
 
 executables = build/plugin/bin/spicyz


### PR DESCRIPTION
In b06e4bf741f we made the package build and test process sequential to
not overwhelm machines with too little RAM. This had the side effect of
making _all builds_ slower.

In this patch we revise that fix but going back to package build and
test parallel by default, but with an option to opt out of this. If the
environment variable `SPICY_ZKG_PROCESSES` is set, we will use that as
the number of build or test jobs to spawn; otherwise we default to a
hardcoded level of parallelism.