### PR TITLE
Fix parsing of evt files not ending in newlines.

### DIFF
--- a/src/compiler/glue-compiler.cc
+++ b/src/compiler/glue-compiler.cc
@@ -346,14 +346,9 @@ void GlueCompiler::preprocessEvtFile(hilti::rt::filesystem::path& path, std::ist
     hilti::util::SourceCodePreprocessor pp({{"ZEEK_VERSION", _zeek_version}});
     int lineno = 0;
 
-    while ( true ) {
+    std::string line;
+    while ( std::getline(in, line) ) {
         lineno++;
-
-        std::string line;
-        std::getline(in, line);
-
-        if ( in.eof() )
-            break;
 
         auto trimmed = hilti::util::trim(line);
         _locations.emplace_back(path, lineno);


### PR DESCRIPTION
When parsing evt files, we previously would manually and explicitly
handle EOF encountered when extracting lines from evt files. This lead
to us incorrectly ignoring the last line if it did not end in a newline.

With this patch we now use the standard pattern of extracting lines
until `getline` returns an error.

Closes #56.