### PR TITLE
Reduce amount of ifdef'd code in headers.

### DIFF
--- a/include/compiler/glue-compiler.h
+++ b/include/compiler/glue-compiler.h
@@ -22,7 +22,6 @@
 
 #include <spicy/ast/declarations/unit-hook.h>
 #include <spicy/ast/types/unit.h>
-#include <zeek-spicy/autogen/config.h>
 
 #include "driver.h"
 
@@ -63,7 +62,6 @@ struct FileAnalyzer {
     std::optional<UnitInfo> unit; /**< The type of the unit to parse the originator side. */
 };
 
-#ifdef HAVE_PACKET_ANALYZERS
 /** Representation of a Spicy packet analyzer, parsed from an EVT file. */
 struct PacketAnalyzer {
     // Information parsed directly from the *.evt file.
@@ -74,7 +72,6 @@ struct PacketAnalyzer {
     // Computed information.
     std::optional<UnitInfo> unit; /**< The type of the unit to parse the originator side. */
 };
-#endif
 
 /**
  * Representation of an expression computing the value of a parameter passed
@@ -175,9 +172,7 @@ private:
     // Parsers for parts from EVT files.
     glue::ProtocolAnalyzer parseProtocolAnalyzer(const std::string& chunk);
     glue::FileAnalyzer parseFileAnalyzer(const std::string& chunk);
-#ifdef HAVE_PACKET_ANALYZERS
     glue::PacketAnalyzer parsePacketAnalyzer(const std::string& chunk);
-#endif
     glue::Event parseEvent(const std::string& chunk);
 
     /** Computes the missing pieces for all `Event` instances.  */
@@ -203,9 +198,7 @@ private:
     std::vector<glue::Event> _events;                        /**< events parsed from EVT files */
     std::vector<glue::ProtocolAnalyzer> _protocol_analyzers; /**< protocol analyzers parsed from EVT files */
     std::vector<glue::FileAnalyzer> _file_analyzers;         /**< file analyzers parsed from EVT files */
-#ifdef HAVE_PACKET_ANALYZERS
-    std::vector<glue::PacketAnalyzer> _packet_analyzers; /**< file analyzers parsed from EVT files */
-#endif
-    std::vector<hilti::Location> _locations; /**< location stack during parsing EVT files */
+    std::vector<glue::PacketAnalyzer> _packet_analyzers;     /**< file analyzers parsed from EVT files */
+    std::vector<hilti::Location> _locations;                 /**< location stack during parsing EVT files */
 };
 } // namespace spicy::zeek

--- a/include/cookie.h
+++ b/include/cookie.h
@@ -14,7 +14,6 @@
 
 #include <hilti/rt/fmt.h>
 
-#include <zeek-spicy/autogen/config.h>
 #include <zeek-spicy/zeek-compat.h>
 
 namespace spicy::zeek::rt {

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -12,7 +12,6 @@
 #include <hilti/rt/library.h>
 #include <hilti/rt/types/port.h>
 
-#include <zeek-spicy/autogen/config.h>
 #include <zeek-spicy/zeek-compat.h>
 
 #ifdef ZEEK_SPICY_PLUGIN_USE_JIT

--- a/include/zeek-reporter.h
+++ b/include/zeek-reporter.h
@@ -11,7 +11,6 @@
 
 #include <string>
 
-#include <zeek-spicy/autogen/config.h>
 #include <zeek-spicy/debug.h>
 
 #include "plugin.h"


### PR DESCRIPTION
This patch is a cleanup patch for #78. We remove generated headers from
public headers to improve compiler cache behavior, and reduce the amount
of ifdef'd code.