### PR TITLE
Wrap different Zeek tag types

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,20 +8,6 @@ environment:
     IMAGE_MACOS_BIG_SUR:  big-sur-base
     IMAGE_MACOS_CATALINA: catalina-base
 
-pre_commit_task:
-  container:
-    dockerfile: ci/Dockerfile
-
-  update_git_script:
-    - git submodule update --recursive --init
-
-  always:
-    pre_commit_cache:
-      folder: /root/.cache/pre-commit
-
-  check_script:
-    - pre-commit run -a
-
 zkg_ubuntu_task:
   timeout_in: 120m
   container:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -112,7 +112,7 @@ public:
      * @return parser, or null if we don't have one for this tag. The pointer will remain valid for the life-time of the
      * process.
      */
-    const spicy::rt::Parser* parserForProtocolAnalyzer(const ::zeek::analyzer::Tag& tag, bool is_orig);
+    const spicy::rt::Parser* parserForProtocolAnalyzer(const spicy::zeek::compat::AnalyzerTag& tag, bool is_orig);
 
     /**
      * Runtime method to retrieve the Spicy parser for a given Zeek file analyzer tag.
@@ -121,7 +121,7 @@ public:
      * @return parser, or null if we don't have one for this tag. The pointer will remain valid for the life-time of the
      * process.
      */
-    const spicy::rt::Parser* parserForFileAnalyzer(const ::zeek::file_analysis::Tag& tag);
+    const spicy::rt::Parser* parserForFileAnalyzer(const spicy::zeek::compat::FileAnalysisTag& tag);
 
 #ifdef HAVE_PACKET_ANALYZERS
     /**
@@ -131,7 +131,7 @@ public:
      * @return parser, or null if we don't have one for this tag. The pointer will remain
      * valid for the life-time of the process.
      */
-    const spicy::rt::Parser* parserForPacketAnalyzer(const ::zeek::packet_analysis::Tag& tag);
+    const spicy::rt::Parser* parserForPacketAnalyzer(const spicy::zeek::compat::PacketAnalysisTag& tag);
 #endif
 
     /**
@@ -143,7 +143,7 @@ public:
      * @param tag original tag we query for how to pass it to script-land.
      * @return desired tag for passing to script-land.
      */
-    ::zeek::analyzer::Tag tagForProtocolAnalyzer(const ::zeek::analyzer::Tag& tag);
+    spicy::zeek::compat::AnalyzerTag tagForProtocolAnalyzer(const spicy::zeek::compat::AnalyzerTag& tag);
 
     /**
      * Runtime method to retrieve the analyzer tag that should be passed to
@@ -154,7 +154,7 @@ public:
      * @param tag original tag we query for how to pass it to script-land.
      * @return desired tag for passing to script-land.
      */
-    ::zeek::file_analysis::Tag tagForFileAnalyzer(const ::zeek::file_analysis::Tag& tag);
+    spicy::zeek::compat::FileAnalysisTag tagForFileAnalyzer(const spicy::zeek::compat::FileAnalysisTag& tag);
 
 #ifdef HAVE_PACKET_ANALYZERS
     /**
@@ -166,7 +166,7 @@ public:
      * @param tag original tag we query for how to pass it to script-land.
      * @return desired tag for passing to script-land.
      */
-    ::zeek::analyzer::Tag tagForPacketAnalyzer(const ::zeek::analyzer::Tag& tag);
+    spicy::zeek::compat::AnalyzerTag tagForPacketAnalyzer(const spicy::zeek::compat::AnalyzerTag& tag);
 #endif
 
     /**
@@ -177,7 +177,7 @@ public:
      * @param analyzer tag of analyer
      * @param enable true to enable, false to disable
      */
-    bool toggleAnalyzer(const ::zeek::analyzer::Tag& tag, bool enable);
+    bool toggleAnalyzer(const spicy::zeek::compat::AnalyzerTag& tag, bool enable);
 
     /**
      * Explicitly enable/disable a file analyzer. By default, all analyzers
@@ -189,7 +189,7 @@ public:
      * @param analyzer tag of analyer
      * @param enable true to enable, false to disable
      */
-    bool toggleAnalyzer(const ::zeek::file_analysis::Tag& tag, bool enable);
+    bool toggleAnalyzer(const spicy::zeek::compat::FileAnalysisTag& tag, bool enable);
 
 #ifdef HAVE_PACKET_ANALYZERS
     /**
@@ -203,7 +203,7 @@ public:
      * @param analyzer tag of analyer
      * @param enable true to enable, false to disable
      */
-    bool toggleAnalyzer(const ::zeek::packet_analysis::Tag& tag, bool enable);
+    bool toggleAnalyzer(const spicy::zeek::compat::PacketAnalysisTag& tag, bool enable);
 #endif
 
     /**
@@ -269,13 +269,13 @@ private:
         std::string name_zeekygen;
         hilti::rt::Protocol protocol = hilti::rt::Protocol::Undef;
         hilti::rt::Vector<hilti::rt::Port> ports;
-        ::zeek::analyzer::Tag::type_t type;
+        spicy::zeek::compat::AnalyzerTag::type_t type;
         std::string linker_scope;
 
         // Filled in during InitPostScript().
         const spicy::rt::Parser* parser_orig;
         const spicy::rt::Parser* parser_resp;
-        ::zeek::analyzer::Tag replaces;
+        spicy::zeek::compat::AnalyzerTag replaces;
     };
 
     /** Captures a registered file analyzer. */
@@ -286,12 +286,12 @@ private:
         std::string name_replaces;
         std::string name_zeekygen;
         hilti::rt::Vector<std::string> mime_types;
-        ::zeek::file_analysis::Tag::type_t type;
+        spicy::zeek::compat::FileAnalysisTag::type_t type;
         std::string linker_scope;
 
         // Filled in during InitPostScript().
         const spicy::rt::Parser* parser;
-        ::zeek::file_analysis::Tag replaces;
+        spicy::zeek::compat::FileAnalysisTag replaces;
     };
 
 #ifdef HAVE_PACKET_ANALYZERS
@@ -301,7 +301,7 @@ private:
         std::string name_analyzer;
         std::string name_parser;
         std::string name_zeekygen;
-        ::zeek::packet_analysis::Tag::type_t type;
+        spicy::zeek::compat::PacketAnalysisTag::type_t type;
         std::string linker_scope;
 
         // Filled in during InitPostScript().

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -283,32 +283,36 @@ void plugin::Zeek_Spicy::Plugin::registerEvent(const std::string& name) {
         _events[name] = ::zeek::detail::install_ID(name.c_str(), mod.c_str(), false, true);
 }
 
-const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForProtocolAnalyzer(const ::zeek::analyzer::Tag& tag,
-                                                                               bool is_orig) {
+const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForProtocolAnalyzer(
+    const ::spicy::zeek::compat::AnalyzerTag& tag, bool is_orig) {
     if ( is_orig )
         return _protocol_analyzers_by_type[tag.Type()].parser_orig;
     else
         return _protocol_analyzers_by_type[tag.Type()].parser_resp;
 }
 
-const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForFileAnalyzer(const ::zeek::file_analysis::Tag& tag) {
+const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForFileAnalyzer(
+    const ::spicy::zeek::compat::FileAnalysisTag& tag) {
     return _file_analyzers_by_type[tag.Type()].parser;
 }
 
 #ifdef HAVE_PACKET_ANALYZERS
-const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForPacketAnalyzer(const ::zeek::packet_analysis::Tag& tag) {
+const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForPacketAnalyzer(
+    const ::spicy::zeek::compat::PacketAnalysisTag& tag) {
     return _packet_analyzers_by_type[tag.Type()].parser;
 }
 #endif
 
-::zeek::analyzer::Tag plugin::Zeek_Spicy::Plugin::tagForProtocolAnalyzer(const ::zeek::analyzer::Tag& tag) {
+::spicy::zeek::compat::AnalyzerTag plugin::Zeek_Spicy::Plugin::tagForProtocolAnalyzer(
+    const ::spicy::zeek::compat::AnalyzerTag& tag) {
     if ( auto r = _protocol_analyzers_by_type[tag.Type()].replaces )
         return r;
     else
         return tag;
 }
 
-::zeek::file_analysis::Tag plugin::Zeek_Spicy::Plugin::tagForFileAnalyzer(const ::zeek::file_analysis::Tag& tag) {
+::spicy::zeek::compat::FileAnalysisTag plugin::Zeek_Spicy::Plugin::tagForFileAnalyzer(
+    const ::spicy::zeek::compat::FileAnalysisTag& tag) {
     if ( auto r = _file_analyzers_by_type[tag.Type()].replaces )
         return r;
     else
@@ -316,13 +320,14 @@ const spicy::rt::Parser* plugin::Zeek_Spicy::Plugin::parserForPacketAnalyzer(con
 }
 
 #ifdef HAVE_PACKET_ANALYZERS
-::zeek::analyzer::Tag plugin::Zeek_Spicy::Plugin::tagForPacketAnalyzer(const ::zeek::analyzer::Tag& tag) {
+::spicy::zeek::compat::AnalyzerTag plugin::Zeek_Spicy::Plugin::tagForPacketAnalyzer(
+    const ::spicy::zeek::compat::AnalyzerTag& tag) {
     // Don't have a replacement mechanism currently.
     return tag;
 }
 #endif
 
-bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::zeek::analyzer::Tag& tag, bool enable) {
+bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::spicy::zeek::compat::AnalyzerTag& tag, bool enable) {
     auto type = tag.Type();
 
     if ( type >= _protocol_analyzers_by_type.size() )
@@ -356,7 +361,7 @@ bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::zeek::analyzer::Tag& tag
     return true;
 }
 
-bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::zeek::file_analysis::Tag& tag, bool enable) {
+bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::spicy::zeek::compat::FileAnalysisTag& tag, bool enable) {
     auto type = tag.Type();
 
     if ( type >= _file_analyzers_by_type.size() )
@@ -407,7 +412,7 @@ bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::zeek::file_analysis::Tag
 }
 
 #ifdef HAVE_PACKET_ANALYZERS
-bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::zeek::packet_analysis::Tag& tag, bool enable) {
+bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::spicy::zeek::compat::PacketAnalysisTag& tag, bool enable) {
     auto type = tag.Type();
 
     if ( type >= _packet_analyzers_by_type.size() )
@@ -427,14 +432,14 @@ bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(const ::zeek::packet_analysis::T
 bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(::zeek::EnumVal* tag, bool enable) {
     if ( ::spicy::zeek::compat::EnumVal_GetType(tag) == ::spicy::zeek::compat::AnalyzerMgr_GetTagType() ) {
         if ( auto analyzer = ::zeek::analyzer_mgr->Lookup(tag) )
-            return toggleAnalyzer(analyzer->Tag(), enable);
+            return toggleAnalyzer(::spicy::zeek::compat::ComponentTag(*analyzer), enable);
         else
             return false;
     }
 
     if ( ::spicy::zeek::compat::EnumVal_GetType(tag) == ::spicy::zeek::compat::FileMgr_GetTagType() ) {
         if ( auto analyzer = ::zeek::file_mgr->Lookup(tag) )
-            return toggleAnalyzer(analyzer->Tag(), enable);
+            return toggleAnalyzer(::spicy::zeek::compat::ComponentTag(*analyzer), enable);
         else
             return false;
     }
@@ -442,7 +447,7 @@ bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(::zeek::EnumVal* tag, bool enabl
 #ifdef HAVE_PACKET_ANALYZERS
     if ( tag->GetType() == ::zeek::packet_mgr->GetTagType() ) {
         if ( auto analyzer = ::zeek::file_mgr->Lookup(tag) )
-            return toggleAnalyzer(analyzer->Tag(), enable);
+            return toggleAnalyzer(::spicy::zeek::compat::ComponentTag(*analyzer), enable);
         else
             return false;
     }

--- a/src/runtime-support.cc
+++ b/src/runtime-support.cc
@@ -262,9 +262,10 @@ static void _data_in(const char* data, uint64_t len, std::optional<uint64_t> off
     }
     else {
         if ( offset )
-            ::zeek::file_mgr->DataIn(data_, len, *offset, ::zeek::analyzer::Tag(), nullptr, false, fid, mime_type);
+            ::zeek::file_mgr->DataIn(data_, len, *offset, ::spicy::zeek::compat::AnalyzerTag(), nullptr, false, fid,
+                                     mime_type);
         else
-            ::zeek::file_mgr->DataIn(data_, len, ::zeek::analyzer::Tag(), nullptr, false, fid, mime_type);
+            ::zeek::file_mgr->DataIn(data_, len, ::spicy::zeek::compat::AnalyzerTag(), nullptr, false, fid, mime_type);
     }
 }
 
@@ -328,7 +329,7 @@ void rt::file_set_size(const hilti::rt::integer::safe<uint64_t>& size) {
         ::zeek::file_mgr->SetSize(size, tag, c->analyzer->Conn(), c->is_orig, fid);
     }
     else
-        ::zeek::file_mgr->SetSize(size, ::zeek::analyzer::Tag(), nullptr, false, fid);
+        ::zeek::file_mgr->SetSize(size, ::spicy::zeek::compat::AnalyzerTag(), nullptr, false, fid);
 }
 
 void rt::file_data_in(const hilti::rt::Bytes& data) { _data_in(data.data(), data.size()); }
@@ -346,7 +347,7 @@ void rt::file_gap(const hilti::rt::integer::safe<uint64_t>& offset, const hilti:
         ::zeek::file_mgr->Gap(offset, len, tag, c->analyzer->Conn(), c->is_orig, fid);
     }
     else
-        ::zeek::file_mgr->Gap(offset, len, ::zeek::analyzer::Tag(), nullptr, false, fid);
+        ::zeek::file_mgr->Gap(offset, len, ::spicy::zeek::compat::AnalyzerTag(), nullptr, false, fid);
 }
 
 void rt::file_end() {


### PR DESCRIPTION
As of zeek-4.2 `Tag` types in Zeek got unified. This leads to issues for
us since we e.g., overload by `Tag` type, or need to be able to handle
individual `Tag` types differently.

This patch introduces wrapper types around Zeek `Tag` types.

Closes #81.