### PR TITLE
Remove duplicate declaration of `file_end`.

### DIFF
--- a/spicy/zeek.spicy
+++ b/spicy/zeek.spicy
@@ -78,9 +78,6 @@ public function file_data_in_at_offset(data: bytes, offset: uint64) : void &cxxn
 ## Signals a gap in a file to Zeek's file analysis.
 public function file_gap(offset: uint64, len: uint64) : void &cxxname="spicy::zeek::rt::file_gap";
 
-## Signals the end of a file to Zeek's file analysis.
-public function file_end() : void &cxxname="spicy::zeek::rt::file_end";
-
 ## Inside a packet analyzer, forwards what data remains after parsing the top-level unit
 ## on to another analyzer. The index specifies the target, per the current dispatcher table.
 public function forward_packet(identifier: uint32) : void &cxxname="spicy::zeek::rt::forward_packet";


### PR DESCRIPTION
While this duplicate declaration is inconsequential on the Spicy side, it
causes issues when generating docs.