### PR TITLE
Make plugin description proper reStructuredText.

### DIFF
--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -446,7 +446,7 @@ bool plugin::Zeek_Spicy::Plugin::toggleAnalyzer(::zeek::EnumVal* tag, bool enabl
 ::zeek::plugin::Configuration plugin::Zeek_Spicy::Plugin::Configure() {
     ::zeek::plugin::Configuration config;
     config.name = "Zeek::Spicy";
-    config.description = "Support for Spicy parsers (*.spicy, *.evt, *.hlto)";
+    config.description = "Support for Spicy parsers (``*.spicy``, ``*.evt``, ``*.hlto``)";
     config.version.major = spicy::zeek::configuration::PluginVersionMajor;
     config.version.minor = spicy::zeek::configuration::PluginVersionMinor;
     config.version.patch = spicy::zeek::configuration::PluginVersionPatch;


### PR DESCRIPTION
If the plugin is built into Zeek the plugin description is used in the
generated reStructuredText documentation. This patch adds code markup to
wildcard expressions so they are not interpreted as reStructuredText
emphasis.