### PR TITLE
Initialize language support in newer Spicy.

### DIFF
--- a/include/config.h.in
+++ b/include/config.h.in
@@ -16,6 +16,8 @@ namespace spicy::zeek::configuration {
 #define ZEEK_SPICY_VERSION_NUMBER ${ZEEK_VERSION_NUMBER}
 #define ZEEK_SPICY_BUILD_DIRECTORY "${CMAKE_BINARY_DIR}"
 
+#define SPICY_VERSION_NUMBER ${SPICY_VERSION_NUMBER}
+
 inline const auto InstallLibDir = "${CMAKE_INSTALL_LIBDIR}";
 inline const auto InstallPrefix = "${CMAKE_INSTALL_PREFIX}";
 

--- a/src/compiler/driver.cc
+++ b/src/compiler/driver.cc
@@ -21,6 +21,12 @@
 // Must come after Bro includes to avoid namespace conflicts.
 #include <spicy/rt/libspicy.h>
 
+#if SPICY_VERSION_NUMBER >= 10500
+#include <hilti/compiler/init.h>
+
+#include <spicy/compiler/init.h>
+#endif
+
 using namespace spicy::zeek;
 using Driver = spicy::zeek::Driver;
 
@@ -122,6 +128,11 @@ Driver::Driver(const char* argv0, hilti::rt::filesystem::path plugin_path, int z
     config.preprocessor_constants["ZEEK_VERSION"] = zeek_version;
 
     _glue = std::make_unique<GlueCompiler>(this, zeek_version);
+
+#if SPICY_VERSION_NUMBER >= 10500
+    hilti::init();
+    spicy::init();
+#endif
 }
 
 Driver::~Driver() {}


### PR DESCRIPTION
This is a companion path to zeek/spicy#1164 where the code to register
language support was made explicit. We now perform explicit
initialization for that if we are compiling against a newer Spicy.