### PR TITLE
Fix linking against static archives.

### DIFF
--- a/cmake/FindSpicy.cmake
+++ b/cmake/FindSpicy.cmake
@@ -117,7 +117,9 @@ function (spicy_link_libraries lib)
                             ${SPICY_LIBRARY_DIRS_RUNTIME})
 
     if (SPICY_HAVE_TOOLCHAIN)
-        target_link_libraries(${lib} "${ARGN}" hilti spicy)
+        # In addition to libhilti and libspicy we also add their dependencies here
+        # so we can link against both shared libraries as well as static archives.
+        target_link_libraries(${lib} "${ARGN}" hilti spicy dl)
     endif ()
 endfunction ()
 


### PR DESCRIPTION
If we are linking against e.g., a static libhilti we do not
implicitly link against its dependencies. Make the link explicit to fix
a otherwise failing link in such setups.

Closes #117.