### PR TITLE
Add support for loading C++ source files with `spicyz`.

### DIFF
--- a/src/compiler/driver.cc
+++ b/src/compiler/driver.cc
@@ -321,6 +321,14 @@ hilti::Result<hilti::Nothing> Driver::loadFile(hilti::rt::filesystem::path file,
             return rc.error();
     }
 
+    if ( ext == ".cc" || ext == ".cxx" ) {
+        ZEEK_DEBUG(hilti::util::fmt("Loading C++ code %s", rpath));
+        if ( auto rc = addInput(rpath) )
+            return hilti::Nothing();
+        else
+            return rc.error();
+    }
+
     return hilti::result::Error(hilti::util::fmt("unknown file type passed to Spicy loader: %s", rpath));
 }
 


### PR DESCRIPTION
The underlying spicy-driver already supports this, but for handling of
EVT files we replaced the internal logic here. This patch adds support
for loading C++ source files.