### PR TITLE
Prevent dead symlinks ending up in Zeek binary packaging.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,11 +209,13 @@ set(AUTOGEN_H "${PROJECT_BINARY_DIR}/include/zeek-spicy/autogen")
 file(MAKE_DIRECTORY ${AUTOGEN_H})
 
 if (ZEEK_SPICY_PLUGIN_INTERNAL_BUILD)
-    # The static build doesn't put the aux files into the build directory
-    # We create links to get the same effect.
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
-    file(CREATE_LINK "${PROJECT_BINARY_DIR}"
-         "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/zeek-spicy" SYMBOLIC)
+    if (NOT BINARY_PACKAGING_MODE)
+        # The static build doesn't put the aux files into the build directory
+        # We create links to get the same effect.
+        file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+        file(CREATE_LINK "${PROJECT_BINARY_DIR}"
+             "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/zeek-spicy" SYMBOLIC)
+    endif ()
 
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cmake")
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/spicy")


### PR DESCRIPTION
If spicy-plugin is built as a Zeek builtin plugin we would have
previously packaged softlinks intended for development. With this patch
we now do not create (and thus package) these symlinks if we are
building a binary package.

Closes #119.