### PR TITLE
Switch bro_int_t to zeek_int_t

### DIFF
--- a/include/runtime-support.h
+++ b/include/runtime-support.h
@@ -712,7 +712,7 @@ inline ::zeek::ValPtr to_val(const T& t, ::zeek::TypePtr target, const std::stri
         // can't allow this ...
         throw InvalidValue("enum values with value max_int not supported by Zeek integration", location);
 
-    bro_int_t bt = (it >= 0 ? it : std::numeric_limits<::bro_int_t>::max());
+    zeek_int_t bt = (it >= 0 ? it : std::numeric_limits<::zeek_int_t>::max());
 
     return target->AsEnumType()->GetEnumVal(bt);
 }

--- a/include/zeek-compat.h
+++ b/include/zeek-compat.h
@@ -78,6 +78,10 @@
 
 //// Import types and globals into the new namespaces.
 
+#if ZEEK_VERSION_NUMBER < 50100 // Zeek < 5.1
+using zeek_int_t = bro_int_t;
+#endif
+
 #if ZEEK_VERSION_NUMBER < 40100 // Zeek < 4.1
 namespace zeek::packet_analysis::TCP {
 using TCPSessionAdapter = ::zeek::analyzer::tcp::TCP_Analyzer;

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -242,7 +242,7 @@ void plugin::Zeek_Spicy::Plugin::registerEnumType(
 
         if ( lval == -1 )
             // Zeek's enum can't be negative, so swap int max_int for our Undef.
-            lval = std::numeric_limits<::bro_int_t>::max();
+            lval = std::numeric_limits<::zeek_int_t>::max();
 
         etype->AddName(ns, name.c_str(), lval, true);
     }


### PR DESCRIPTION
For pre-5.1 versions, alias bro_int_t as zeek_int_t into the global
namespace.

Fixes #128.