### PR TITLE
Fix spelling of Zeek-side tags for packet analyzers.

### DIFF
--- a/include/plugin.h
+++ b/include/plugin.h
@@ -277,6 +277,7 @@ private:
         std::string linker_scope;
 
         // Filled in after registering the analyzer.
+        std::string name_zeek;
         std::string name_zeekygen;
         spicy::zeek::compat::AnalyzerTag::type_t type;
         const spicy::rt::Parser* parser_orig;
@@ -302,6 +303,7 @@ private:
         std::string linker_scope;
 
         // Filled in after registering the analyzer.
+        std::string name_zeek;
         std::string name_zeekygen;
         spicy::zeek::compat::FileAnalysisTag::type_t type;
         const spicy::rt::Parser* parser;
@@ -324,6 +326,7 @@ private:
         std::string linker_scope;
 
         // Filled in after registering the analyzer.
+        std::string name_zeek;
         std::string name_zeekygen;
         spicy::zeek::compat::PacketAnalysisTag::type_t type;
         const spicy::rt::Parser* parser;

--- a/src/compiler/glue-compiler.cc
+++ b/src/compiler/glue-compiler.cc
@@ -494,7 +494,7 @@ glue::ProtocolAnalyzer GlueCompiler::parseProtocolAnalyzer(const std::string& ch
 
     eat_token(chunk, &i, "protocol");
     eat_token(chunk, &i, "analyzer");
-    a.name = hilti::util::replace(extract_id(chunk, &i), "::", "_");
+    a.name = extract_id(chunk, &i).str();
 
     eat_token(chunk, &i, "over");
 
@@ -599,7 +599,7 @@ glue::FileAnalyzer GlueCompiler::parseFileAnalyzer(const std::string& chunk) {
 
     eat_token(chunk, &i, "file");
     eat_token(chunk, &i, "analyzer");
-    a.name = hilti::util::replace(extract_id(chunk, &i).str(), "::", "_");
+    a.name = extract_id(chunk, &i).str();
 
     eat_token(chunk, &i, ":");
 
@@ -644,9 +644,6 @@ glue::PacketAnalyzer GlueCompiler::parsePacketAnalyzer(const std::string& chunk)
 
     eat_token(chunk, &i, "packet");
     eat_token(chunk, &i, "analyzer");
-
-    // We don't normalize the name here so that the user can address
-    // it with the expected spelling.
     a.name = extract_id(chunk, &i).str();
 
     eat_token(chunk, &i, ":");

--- a/tests/Baseline/zeek.packet-analyzer/weird.log
+++ b/tests/Baseline/zeek.packet-analyzer/weird.log
@@ -7,5 +7,5 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	name	addl	notice	peer	source
 #types	time	string	addr	port	addr	port	string	string	bool	string	string
-XXXXXXXXXX.XXXXXX	-	-	-	-	-	test_weird	-	F	zeek	SPICY__RAWLAYER
+XXXXXXXXXX.XXXXXX	-	-	-	-	-	test_weird	-	F	zeek	SPICY_RAWLAYER
 #close XXXX-XX-XX-XX-XX-XX

--- a/tests/zeek/packet-analyzer-on-ip.zeek
+++ b/tests/zeek/packet-analyzer-on-ip.zeek
@@ -5,7 +5,7 @@ module PacketAnalyzer::SPICY_RAWLAYER;
 
 event zeek_init()
 	{
-	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 255, "spicy::RawLayer") ) # modified trace to have IP proto 255
+	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 255, "spicy_RawLayer") ) # modified trace to have IP proto 255
 		print "cannot register raw analyzer on top of IP";
 	}
 

--- a/tests/zeek/packet-analyzer-violation.zeek
+++ b/tests/zeek/packet-analyzer-violation.zeek
@@ -23,6 +23,6 @@ module TEST;
 event zeek_init()
 {
 	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("Ethernet", 0x6666,
-	    "spicy::TEST") )
+	    "spicy_TEST") )
 		print "cannot register spicy analyzer";
 }

--- a/tests/zeek/packet-analyzer.zeek
+++ b/tests/zeek/packet-analyzer.zeek
@@ -7,9 +7,9 @@ module PacketAnalyzer::SPICY_RAWLAYER;
 
 event zeek_init()
 	{
-	PacketAnalyzer::register_packet_analyzer(PacketAnalyzer::ANALYZER_ETHERNET, 0x88b5, PacketAnalyzer::ANALYZER_SPICY__RAWLAYER);
+	PacketAnalyzer::register_packet_analyzer(PacketAnalyzer::ANALYZER_ETHERNET, 0x88b5, PacketAnalyzer::ANALYZER_SPICY_RAWLAYER);
 
-	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("spicy::RawLayer", 0x4950, "IP") )
+	if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("spicy_RawLayer", 0x4950, "IP") )
 		print "cannot register IP analyzer";
 	}
 


### PR DESCRIPTION
They used to turn out as `ANALYZER_SPICY__FOO`. Now they are `ANALYZER_SPICY_FOO`.

We also unify how the derivation of the Zeek-side name happens across all three types of analyzers. On the Spicy side, analyzer names now remain in their original spelling (i.e., `Spicy::Foo` instead of `Spicy_Foo`). On the Zeek-side, the name for packet analyzers is now `Spicy_Foo` instead of `Spicy::Foo` (that was the case for protocol/file analyzers already).

On the Zeek side, the removal of the double-underscore and the name change for packet analyzer is user-visible and could break some scripts. It'll most likely be encountered in logs and, more importantly, in scripts configuring a packet analyzer through calls to `register_packet_analyzer_by_name()` and `try_register_packet_analyzer_by_name()`. Calls to the former will need to have double-underscores removed, and calls to the latter will need to switch from `Spicy::Foo` to `Spicy_Foo`. This is a bit unfortunate, but I don't see a way to avoid it if we want to become consistent; and doing that change now seems a better time than later.

This is on top of #139 