### PR TITLE
Tie plugin to Spicy version, and analyzers to plugin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,17 @@ endif ()
 ### Create config file.
 ###
 
+# Create a version string that's a valid C identifier. We use only the actual
+# version number, no development postfix, to make ccache a bit happier.
+string(REGEX REPLACE "([0-9]+\.[0-9]+\.[0-9]+).*" "\\1" ZEEK_SPICY_PLUGIN_VERSION_C_IDENT
+                     "${ZEEK_SPICY_PLUGIN_VERSION}")
+string(REPLACE "." "_" ZEEK_SPICY_PLUGIN_VERSION_C_IDENT "${ZEEK_SPICY_PLUGIN_VERSION_C_IDENT}")
+
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    # Distinguish between release and debug builds.
+    set(ZEEK_SPICY_PLUGIN_VERSION_C_IDENT "${ZEEK_SPICY_PLUGIN_VERSION_C_IDENT}_debug")
+endif ()
+
 configure_file(${PROJECT_SOURCE_DIR}/include/config.h.in ${AUTOGEN_H}/config.h)
 
 ###

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -16,6 +16,7 @@ namespace spicy::zeek::configuration {
 #define ZEEK_SPICY_VERSION_NUMBER ${ZEEK_VERSION_NUMBER}
 #define ZEEK_SPICY_BUILD_DIRECTORY "${CMAKE_BINARY_DIR}"
 
+// Version of Spicy that plugin was compiled against.
 #define SPICY_VERSION_NUMBER ${SPICY_VERSION_NUMBER}
 
 inline const auto BuildLibDir = "${ZEEK_SPICY_PLUGIN_BUILD_LIBDIR}";
@@ -40,3 +41,10 @@ inline const auto PluginScriptsDirectory = "${ZEEK_SPICY_SCRIPTS_DIR}";
 inline const auto StaticBuildName = "${ZEEK_SPICY_STATIC_BUILD_NAME}";
 
 }
+
+// A C function that has our version encoded into its name. One can link a
+// target against this to ensure that it won't load if the versions differ
+// between when the target was compiled vs when it's run.
+#define ZEEK_SPICY_PLUGIN_VERSION_FUNCTION spicy_plugin_version_@ZEEK_SPICY_PLUGIN_VERSION_C_IDENT@
+#define ZEEK_SPICY_PLUGIN_VERSION_FUNCTION_AS_STRING "spicy_plugin_version_@ZEEK_SPICY_PLUGIN_VERSION_C_IDENT@"
+extern "C" const char* ZEEK_SPICY_PLUGIN_VERSION_FUNCTION();

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -345,6 +345,8 @@ private:
         bool operator!=(const PacketAnalyzerInfo& other) const { return ! (*this == other); }
     };
 
+    std::string _spicy_version;
+
     std::vector<ProtocolAnalyzerInfo> _protocol_analyzers_by_type;
     std::vector<FileAnalyzerInfo> _file_analyzers_by_type;
     std::vector<PacketAnalyzerInfo> _packet_analyzers_by_type;

--- a/src/compiler/glue-compiler.cc
+++ b/src/compiler/glue-compiler.cc
@@ -750,7 +750,19 @@ bool GlueCompiler::compile() {
     import_ = hilti::builder::import(ID("hilti"), ".hlt");
     init_module.add(std::move(import_));
 
+    // Declare the plugin's version function.
+    auto cxxname = hilti::AttributeSet(
+        {hilti::Attribute("&cxxname", builder::string(ZEEK_SPICY_PLUGIN_VERSION_FUNCTION_AS_STRING)),
+         hilti::Attribute("&have_prototype", builder::bool_(true))});
+    auto version_function =
+        hilti::builder::function("zeek_spicy_plugin_version", type::String(), {}, type::function::Flavor::Standard,
+                                 declaration::Linkage::Public, function::CallingConvention::Standard, cxxname);
+    init_module.add(std::move(version_function));
+
     auto preinit_body = hilti::builder::Builder(_driver->context());
+
+    // Call the plugin's version function.
+    preinit_body.addCall("zeek_spicy_plugin_version", {});
 
     for ( auto&& [id, m] : _spicy_modules )
         m->spicy_module = hilti::Module(hilti::ID(hilti::util::fmt("spicy_hooks_%s", id)));

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -75,6 +75,14 @@ private:
 };
 
 plugin::Zeek_Spicy::Plugin::Plugin() {
+#ifdef HILTI_VERSION_FUNCTION
+    // This ensures version compatibility at dlopen() time  by requiring the
+    // versioned symbol to be present. The symbol is available starting with
+    // Spicy 1.6.
+    _spicy_version = HILTI_VERSION_FUNCTION();
+#endif
+
+    // Not sure if with the with the check above, we still need this? Can't hurt I guess.
     if ( spicy::zeek::configuration::ZeekVersionNumber != ZEEK_VERSION_NUMBER )
         reporter::fatalError(
             hilti::rt::fmt("Zeek version mismatch: running with Zeek %d, but plugin compiled for Zeek %s",

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -33,6 +33,8 @@ const hilti::logging::DebugStream ZeekPlugin("zeek");
 }
 #endif
 
+const char* ZEEK_SPICY_PLUGIN_VERSION_FUNCTION() { return spicy::zeek::configuration::PluginVersion; }
+
 plugin::Zeek_Spicy::Plugin SpicyPlugin;
 plugin::Zeek_Spicy::Plugin* ::plugin::Zeek_Spicy::OurPlugin = &SpicyPlugin;
 


### PR DESCRIPTION
This uses versions-encoded-in-function names to (1) make sure the plugin gets rebuild if the Spicy version changes, and (2) analyzers get rebuild if the plugin versions changes. Through a separate Spicy-side changes, analyzers are in additional also tied to the Spicy version directly (https://github.com/zeek/spicy/pull/1282)