### PR TITLE
Adjust plugin for changes from zeek/spicy#1326.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(AUX_HEADERS
     include/zeek-spicy/protocol-analyzer.h
     include/zeek-spicy/runtime-support.h
     include/zeek-spicy/zeek-compat.h
+    include/zeek-spicy/spicy-compat.h
     include/zeek-spicy/zeek-reporter.h)
 
 set(AUX_SPICY spicy/zeek.spicy spicy/zeek_file.spicy spicy/zeek_rt.hlt)

--- a/include/spicy-compat.h
+++ b/include/spicy-compat.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
+//
+// Provides backwards compatibility for Spicy Zeek versions.
+
+#pragma once
+
+#include <zeek-spicy/autogen/config.h>
+
+namespace spicy::compat {
+
+// Gets the integer value of an enum.
+template<typename E>
+auto enum_value(E e) {
+#if SPICY_VERSION_NUMBER < 10700
+    return e;
+#else
+    return typename E::Value(e.value());
+#endif
+}
+
+} // namespace spicy::compat

--- a/src/compiler/glue-compiler.cc
+++ b/src/compiler/glue-compiler.cc
@@ -14,6 +14,7 @@
 
 #include <spicy/global.h>
 #include <zeek-spicy/autogen/config.h>
+#include <zeek-spicy/spicy-compat.h>
 
 #include "debug.h"
 
@@ -795,7 +796,7 @@ bool GlueCompiler::compile() {
 
         hilti::ID protocol;
 
-        switch ( a.protocol ) {
+        switch ( spicy::compat::enum_value(a.protocol) ) {
             case hilti::rt::Protocol::TCP: protocol = hilti::ID("hilti::Protocol::TCP"); break;
             case hilti::rt::Protocol::UDP: protocol = hilti::ID("hilti::Protocol::UDP"); break;
             default: hilti::logger().internalError("unexpected protocol");

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -24,6 +24,7 @@
 #include <zeek-spicy/packet-analyzer.h>
 #include <zeek-spicy/plugin.h>
 #include <zeek-spicy/protocol-analyzer.h>
+#include <zeek-spicy/spicy-compat.h>
 #include <zeek-spicy/zeek-compat.h>
 #include <zeek-spicy/zeek-reporter.h>
 
@@ -178,7 +179,7 @@ void plugin::Zeek_Spicy::Plugin::registerProtocolAnalyzer(const std::string& nam
 
     ::zeek::analyzer::Component::factory_callback factory = nullptr;
 
-    switch ( proto ) {
+    switch ( spicy::compat::enum_value(proto) ) {
         case hilti::rt::Protocol::TCP: factory = spicy::zeek::rt::TCP_Analyzer::InstantiateAnalyzer; break;
         case hilti::rt::Protocol::UDP: factory = spicy::zeek::rt::UDP_Analyzer::InstantiateAnalyzer; break;
         default: reporter::error("unsupported protocol in analyzer"); return;
@@ -603,7 +604,7 @@ void plugin::Zeek_Spicy::Plugin::InitPreScript() {
 
 // Returns a port's Zeek-side transport protocol.
 static ::TransportProto transport_protocol(const hilti::rt::Port port) {
-    switch ( port.protocol() ) {
+    switch ( spicy::compat::enum_value(port.protocol()) ) {
         case hilti::rt::Protocol::TCP: return ::TransportProto::TRANSPORT_TCP;
         case hilti::rt::Protocol::UDP: return ::TransportProto::TRANSPORT_UDP;
         case hilti::rt::Protocol::ICMP: return ::TransportProto::TRANSPORT_ICMP;

--- a/tests/Baseline/zeek.spicyz-paths/files
+++ b/tests/Baseline/zeek.spicyz-paths/files
@@ -15,6 +15,7 @@ include/zeek-spicy/packet-analyzer.h
 include/zeek-spicy/plugin.h
 include/zeek-spicy/protocol-analyzer.h
 include/zeek-spicy/runtime-support.h
+include/zeek-spicy/spicy-compat.h
 include/zeek-spicy/zeek-compat.h
 include/zeek-spicy/zeek-reporter.h
 spicy


### PR DESCRIPTION
To address zeek/spicy#1326 we changed the code generation for enums to emit a proper runtime type, in particular a type which has defined semantics for value initialization.

This patch adds compatibility code so the plugin can deal with these generated enums types in addition to the previous format for backwards compatibility.