### PR TITLE
Only add plugin directory to library paths if not building standalone.

### DIFF
--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -588,7 +588,9 @@ void plugin::Zeek_Spicy::Plugin::InitPreScript() {
     if ( auto dir = hilti::rt::getenv("ZEEK_SPICY_PATH") )
         addLibraryPaths(*dir);
 
-    addLibraryPaths(hilti::rt::normalizePath(OurPlugin->PluginDirectory()).string() + "/spicy");
+    if ( const auto& dir = OurPlugin->PluginDirectory(); ! dir.empty() )
+        addLibraryPaths(hilti::rt::normalizePath(dir).string() + "/spicy");
+
     autoDiscoverModules();
 
     if ( strlen(spicy::zeek::configuration::PluginScriptsDirectory) &&


### PR DESCRIPTION
For builtin plugins `PluginDirectory` returns an empty string. This lead to use adding a non-existing directory `/spicy` to the library paths in that case. This patch catches the builtin case and skips extending the library paths in that case.

Closes #150.