### PR TITLE
Revert moving Zeek includes out of `zeek-compat.h.`

### DIFF
--- a/include/cookie.h
+++ b/include/cookie.h
@@ -18,9 +18,6 @@
 
 #include <zeek-spicy/zeek-compat.h>
 
-#include <zeek/file_analysis/Analyzer.h>
-#include <zeek/packet_analysis/protocol/tcp/TCPSessionAdapter.h>
-
 namespace spicy::zeek::rt {
 
 namespace cookie {

--- a/include/driver.h
+++ b/include/driver.h
@@ -10,8 +10,6 @@
 
 #include <zeek-spicy/zeek-compat.h>
 
-#include <zeek/plugin/Plugin.h>
-
 namespace spicy::rt {
 struct Parser;
 }

--- a/include/file-analyzer.h
+++ b/include/file-analyzer.h
@@ -14,8 +14,6 @@
 #include <zeek-spicy/cookie.h>
 #include <zeek-spicy/zeek-compat.h>
 
-#include <zeek/file_analysis/Analyzer.h>
-
 namespace spicy::zeek::rt {
 
 /** Parsing state for a file. */

--- a/include/protocol-analyzer.h
+++ b/include/protocol-analyzer.h
@@ -14,8 +14,6 @@
 #include <zeek-spicy/cookie.h>
 #include <zeek-spicy/zeek-compat.h>
 
-#include <zeek/analyzer/protocol/tcp/TCP.h>
-
 namespace spicy::zeek::rt {
 
 /** Parsing state for one endpoint of the connection. */

--- a/include/runtime-support.h
+++ b/include/runtime-support.h
@@ -23,8 +23,6 @@
 #include <zeek-spicy/spicy-compat.h>
 #include <zeek-spicy/zeek-compat.h>
 
-#include <zeek/Desc.h>
-
 namespace spicy::zeek::rt {
 
 /**

--- a/include/zeek-compat.h
+++ b/include/zeek-compat.h
@@ -6,7 +6,7 @@
 
 #include <zeek-spicy/autogen/config.h>
 
-#include <zeek/util.h>
+#include <zeek/zeek-config.h>
 
 #ifdef ZEEK_VERSION_NUMBER
 #if ZEEK_SPICY_VERSION_NUMBER != ZEEK_VERSION_NUMBER
@@ -19,7 +19,46 @@
 #endif
 #endif
 
+//// Collect all the Zeek includes here that we need anywhere in the plugin.
+
+#if ZEEK_DEBUG_BUILD
+#ifndef DEBUG
+#define SPICY_PLUGIN_DEBUG_DEFINED
+#define DEBUG
+#endif
+#endif
+
+#include <zeek/Conn.h>
+#include <zeek/DebugLogger.h>
+#include <zeek/Desc.h>
+#include <zeek/Event.h>
+#include <zeek/EventHandler.h>
+#include <zeek/EventRegistry.h>
+#include <zeek/Expr.h>
+#include <zeek/IPAddr.h>
+#include <zeek/Reporter.h>
+#include <zeek/Tag.h>
+#include <zeek/Type.h>
+#include <zeek/Val.h>
+#include <zeek/Var.h>
+#include <zeek/analyzer/Analyzer.h>
+#include <zeek/analyzer/Manager.h>
+#include <zeek/analyzer/protocol/pia/PIA.h>
+#include <zeek/analyzer/protocol/tcp/TCP.h>
+#include <zeek/file_analysis/Analyzer.h>
+#include <zeek/file_analysis/File.h>
+#include <zeek/file_analysis/Manager.h>
+#include <zeek/module_util.h>
+#include <zeek/packet_analysis/Analyzer.h>
+#include <zeek/plugin/Plugin.h>
+
+#ifdef SPICY_PLUGIN_DEBUG_DEFINED
+#undef DEBUG
+#undef SPICY_PLUGIN_DEBUG_DEFINED
+#endif
+
+//// Import types and globals into the new namespaces.
+
 #if ZEEK_VERSION_NUMBER < 50100 // Zeek < 5.1
-#include <zeek/zeek-config.h>
 using zeek_int_t = bro_int_t;
 #endif

--- a/include/zeek-reporter.h
+++ b/include/zeek-reporter.h
@@ -13,9 +13,6 @@
 
 #include <zeek-spicy/debug.h>
 
-#include <zeek/file_analysis/Analyzer.h>
-#include <zeek/packet_analysis/Analyzer.h>
-
 #include "plugin.h"
 
 namespace spicy::zeek::reporter {

--- a/src/file-analyzer.cc
+++ b/src/file-analyzer.cc
@@ -8,8 +8,6 @@
 #include <zeek-spicy/runtime-support.h>
 #include <zeek-spicy/zeek-reporter.h>
 
-#include <zeek/file_analysis/File.h>
-
 #include "consts.bif.h"
 #include "events.bif.h"
 

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -28,11 +28,6 @@
 #include <zeek-spicy/zeek-compat.h>
 #include <zeek-spicy/zeek-reporter.h>
 
-#include <zeek/analyzer/Component.h>
-#include <zeek/analyzer/Manager.h>
-#include <zeek/file_analysis/Component.h>
-#include <zeek/file_analysis/Manager.h>
-
 #ifdef ZEEK_SPICY_PLUGIN_USE_JIT
 namespace spicy::zeek::debug {
 const hilti::logging::DebugStream ZeekPlugin("zeek");

--- a/src/runtime-support.cc
+++ b/src/runtime-support.cc
@@ -11,17 +11,6 @@
 #include <zeek-spicy/zeek-compat.h>
 #include <zeek-spicy/zeek-reporter.h>
 
-#include <zeek/Conn.h>
-#include <zeek/Event.h>
-#include <zeek/analyzer/Analyzer.h>
-#include <zeek/analyzer/Manager.h>
-#include <zeek/analyzer/protocol/pia/PIA.h>
-#include <zeek/analyzer/protocol/tcp/TCP.h>
-#include <zeek/file_analysis/Analyzer.h>
-#include <zeek/file_analysis/File.h>
-#include <zeek/file_analysis/Manager.h>
-#include <zeek/session/Manager.h>
-
 using namespace spicy::zeek;
 using namespace plugin::Zeek_Spicy;
 

--- a/src/zeek-reporter.cc
+++ b/src/zeek-reporter.cc
@@ -8,8 +8,6 @@
 #include <zeek-spicy/zeek-compat.h>
 #include <zeek-spicy/zeek-reporter.h>
 
-#include <zeek/file_analysis/Analyzer.h>
-
 using namespace spicy::zeek;
 
 void reporter::error(const std::string& msg) { ::zeek::reporter->Error("%s", msg.c_str()); }


### PR DESCRIPTION
This reverts most of `58facecloth`. The problem is that the Zeek includes need some consistent handling in terms of preprocessor setup (`DEBUG`) and inclusion of `zeek-config.h`. The old `zeek-compat.h` used to handle that, but we lost it by moving the includes over into individual files. As a result, I saw some ill-defined crashes inside the plugin, depending on local configuration/environment.

This reverts most of the previous the change because it's easier/safer to handle this centrally than adding the logic to all files needing to include some Zeek header.