### PR TITLE
Add a script-level constant indicating Spicy availability.

### DIFF
--- a/scripts/__preload__.zeek
+++ b/scripts/__preload__.zeek
@@ -4,6 +4,9 @@ module Spicy;
 
 export {
 # doc-options-start
+    # Constant for testing if Spicy is available.
+    const available = T;
+
     ## Activate compile-time debugging output for given debug streams (comma-separated list).
     const codegen_debug = "" &redef;
 

--- a/src/consts.bif
+++ b/src/consts.bif
@@ -1,6 +1,9 @@
 
 module Spicy;
 
+# Constant for testing if Spicy is available.
+const available: bool;
+
 # Activate compile-time debugging output for given debug streams (comma-separated list).
 const codegen_debug: string;
 

--- a/tests/zeek/availability.zeek
+++ b/tests/zeek/availability.zeek
@@ -1,0 +1,13 @@
+# @TEST-EXEC: zeek %INPUT | grep -q yes
+# @TEST-EXEC: zeek -b Zeek::Spicy %INPUT | grep -q yes
+# @TEST-EXEC: if zeek -N Zeek::Spicy | grep -q built-in; then zeek -b %INPUT | grep -q yes; else  zeek -b %INPUT | grep -q no; fi
+#
+# @TEST-DOC: Confirms `Zeek::available` signals correctly whether the Spicy plugin is loaded and active.
+#
+# Note that bare mode, by default, doesn't activate the plugin.
+
+@ifdef ( Spicy::available )
+    print "yes";
+@else
+    print "no";
+@endif


### PR DESCRIPTION
This enables Zeek scripts to test for availability of Spicy through
`@ifdef ( Spicy::available )`.
