### PR TITLE
Switch to using Spicy's new `accept_input`/`decline_input` hooks.

### DIFF
--- a/spicy/zeek.spicy
+++ b/spicy/zeek.spicy
@@ -6,10 +6,16 @@ module zeek;
 
 %cxx-include = "zeek-spicy/runtime-support.h";
 
-## Triggers a DPD protocol confirmation for the current connection.
+## [Deprecated] Triggers a DPD protocol confirmation for the current connection.
+##
+## This function has been deprecated and will be removed. Use ``spicy::accept_input``
+## instead, which will have the same effect with Zeek.
 public function confirm_protocol() : void &cxxname="spicy::zeek::rt::confirm_protocol";
 
-## Triggers a DPD protocol violation for the current connection.
+## [Deprecated] Triggers a DPD protocol violation for the current connection.
+##
+## This function has been deprecated and will be removed. Use ``spicy::decline_input``
+## instead, which will have the same effect with Zeek.
 public function reject_protocol(reason: string) : void &cxxname="spicy::zeek::rt::reject_protocol";
 
 ## Reports a "weird" to Zeek. This should be used with similar semantics as in

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -604,6 +604,28 @@ static ::TransportProto transport_protocol(const hilti::rt::Port port) {
     }
 }
 
+static void hook_accept_input() {
+    auto cookie = static_cast<rt::Cookie*>(hilti::rt::context::cookie());
+    assert(cookie);
+
+    if ( auto x = std::get_if<rt::cookie::ProtocolAnalyzer>(cookie) ) {
+        auto tag = plugin::Zeek_Spicy::OurPlugin->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());
+        ZEEK_DEBUG(hilti::rt::fmt("confirming protocol %s", tag.AsString()));
+        return x->analyzer->AnalyzerConfirmation(tag);
+    }
+}
+
+static void hook_decline_input(const std::string& reason) {
+    auto cookie = static_cast<rt::Cookie*>(hilti::rt::context::cookie());
+    assert(cookie);
+
+    if ( auto x = std::get_if<rt::cookie::ProtocolAnalyzer>(cookie) ) {
+        auto tag = plugin::Zeek_Spicy::OurPlugin->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());
+        ZEEK_DEBUG(hilti::rt::fmt("rejecting protocol %s", tag.AsString()));
+        return x->analyzer->AnalyzerViolation("protocol rejected", nullptr, 0, tag);
+    }
+}
+
 void plugin::Zeek_Spicy::Plugin::InitPostScript() {
     zeek::plugin::Plugin::InitPostScript();
 
@@ -630,17 +652,22 @@ void plugin::Zeek_Spicy::Plugin::InitPostScript() {
     // Init runtime, which will trigger all initialization code to execute.
     ZEEK_DEBUG("Initializing Spicy runtime");
 
-    auto config = hilti::rt::configuration::get();
+    auto hilti_config = hilti::rt::configuration::get();
 
     if ( ::zeek::id::find_const("Spicy::enable_print")->AsBool() ) //NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-        config.cout = std::cout;
+        hilti_config.cout = std::cout;
     else
-        config.cout.reset();
+        hilti_config.cout.reset();
 
-    config.abort_on_exceptions = ::zeek::id::find_const("Spicy::abort_on_exceptions")->AsBool();
-    config.show_backtraces = ::zeek::id::find_const("Spicy::show_backtraces")->AsBool();
+    hilti_config.abort_on_exceptions = ::zeek::id::find_const("Spicy::abort_on_exceptions")->AsBool();
+    hilti_config.show_backtraces = ::zeek::id::find_const("Spicy::show_backtraces")->AsBool();
 
-    hilti::rt::configuration::set(config);
+    hilti::rt::configuration::set(hilti_config);
+
+    auto spicy_config = spicy::rt::configuration::get();
+    spicy_config.hook_accept_input = hook_accept_input;
+    spicy_config.hook_decline_input = hook_decline_input;
+    spicy::rt::configuration::set(std::move(spicy_config));
 
     try {
         hilti::rt::init();

--- a/tests/Baseline/zeek.ssh-banner/analyzer.log
+++ b/tests/Baseline/zeek.ssh-banner/analyzer.log
@@ -8,5 +8,5 @@
 #fields	ts	cause	analyzer_kind	analyzer_name	uid	fuid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	failure_reason	failure_data
 #types	time	string	string	string	string	string	addr	port	addr	port	string	string
 XXXXXXXXXX.XXXXXX	violation	protocol	SPICY_SSH	CHhAvVGS1DHFjwGM9	-	141.142.228.5	53595	54.243.55.129	80	protocol rejected	-
-XXXXXXXXXX.XXXXXX	violation	protocol	SPICY_SSH	CHhAvVGS1DHFjwGM9	-	141.142.228.5	53595	54.243.55.129	80	failed to match regular expression (<...>/ssh.spicy:6:15)	POST /post HTTP/1.1\x0d\x0aUser-Agent: curl/7.
+XXXXXXXXXX.XXXXXX	violation	protocol	SPICY_SSH	CHhAvVGS1DHFjwGM9	-	141.142.228.5	53595	54.243.55.129	80	failed to match regular expression (<...>/ssh.spicy:7:15)	POST /post HTTP/1.1\x0d\x0aUser-Agent: curl/7.
 #close XXXX-XX-XX-XX-XX-XX

--- a/tests/Baseline/zeek.ssh-banner/output
+++ b/tests/Baseline/zeek.ssh-banner/output
@@ -6,5 +6,5 @@ SSH banner, [orig_h=192.150.186.169, orig_p=49244/tcp, resp_h=131.159.14.23, res
 SSH banner, [orig_h=192.150.186.169, orig_p=49244/tcp, resp_h=131.159.14.23, resp_p=22/tcp], T, 2.0, OpenSSH_3.8.1p1
 confirm, Analyzer::ANALYZER_SPICY_SSH
 === violation
-violation, Analyzer::ANALYZER_SPICY_SSH, failed to match regular expression (<...>/ssh.spicy:6:15)
+violation, Analyzer::ANALYZER_SPICY_SSH, failed to match regular expression (<...>/ssh.spicy:7:15)
 violation, Analyzer::ANALYZER_SPICY_SSH, protocol rejected

--- a/tests/zeek/ssh-banner.zeek
+++ b/tests/zeek/ssh-banner.zeek
@@ -43,6 +43,7 @@ event ssh::banner(c: connection, is_orig: bool, version: string, software: strin
 # @TEST-START-FILE ssh.spicy
 module SSH;
 
+import spicy;
 import zeek;
 
 public type Banner = unit {
@@ -51,8 +52,8 @@ public type Banner = unit {
     dash    : /-/;
     software: /[^\r\n]*/ { zeek::weird("my_weird", $$.decode()); }
 
-    on %done { zeek::confirm_protocol(); assert zeek::uid() == "CHhAvVGS1DHFjwGM9"; }
-    on %error { zeek::reject_protocol("kaputt"); }
+    on %done { spicy::accept_input(); assert zeek::uid() == "CHhAvVGS1DHFjwGM9"; }
+    on %error { spicy::decline_input("kaputt"); }
 };
 # @TEST-END-FILE
 


### PR DESCRIPTION
This also deprecates `zeek::confirm_protocol()` and
`zeek::reject_protocol()` in the favor of the Spicy-wide
`spicy::accept_input` and `spicy::decline_input()`.
