### PR TITLE
Add explicit dependency of spicyz on its runtime files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,9 @@ if (ZEEK_SPICY_PLUGIN_INTERNAL_BUILD)
         COMMAND ${CMAKE_COMMAND} -E copy ${AUX_TESTS_SCRIPTS} ${PROJECT_BINARY_DIR}/tests/Scripts/
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+    # spicyz can only work if its runtime dependencies are in place.
+    add_dependencies(spicyz copy-zeek-spicy-dist-files)
+
     # Note for static builds: We can't easily make Zeek's include headers
     # available inside the build directory. They need to be already installed
     # somewhere. Then set HILTI_CXX_INCLUDE_DIRS accordingly.


### PR DESCRIPTION
If spicy-plugin is built as part of Zeek we want to be able to use a simple dependency on `spicy` when declaring Spicy analyzers in the Zeek tree (this is in fact exactly what the macro `spicy_add_analyzer` does). In order for `spicy` to work when built into Zeek we need its runtime dependencies like e.g., `zeek_rt.hlt` in place before using it.

This patch adds an explicit dependency of `spicyz` on `copy-zeek-spicy-dist-files` which achieves just that.