### PR TITLE
Include zeek-version.h if zeek-config.h does not define ZEEK_VERSION_…

### DIFF
--- a/include/plugin/zeek-compat.h
+++ b/include/plugin/zeek-compat.h
@@ -8,7 +8,13 @@
 
 #include <zeek/zeek-config.h>
 
-#ifdef ZEEK_VERSION_NUMBER
+// When building as internal plugin, the newest Zeek version does not define
+// ZEEK_VERSION_NUMBER through zeek-config.h, it'll be in the new
+// zeek/zeek-version.h header.
+#if __has_include(<zeek/zeek-version.h>)
+#include <zeek/zeek-version.h>
+#endif
+
 #if ZEEK_SPICY_VERSION_NUMBER != ZEEK_VERSION_NUMBER
 #define STR(x) __STR(x)
 #define __STR(x) #x
@@ -16,7 +22,6 @@
 #error "Mismatch in Zeek version numbers"
 #undef __STR
 #undef STR
-#endif
 #endif
 
 //// Collect all the Zeek includes here that we need anywhere in the plugin.


### PR DESCRIPTION
…NUMBER

This is for zeek/zeek#2776 where zeek-config.h will not provide
ZEEK_VERSION and ZEEK_VERSION_NUMBER anymore when building an
internal plugin.