### PR TITLE
Add a Spicy::version() bif to return SPICY_VERSION_NUMBER

### DIFF
--- a/src/plugin/functions.bif
+++ b/src/plugin/functions.bif
@@ -4,6 +4,8 @@ module Spicy;
 %%{
     #include "zeek-spicy/plugin/zeek-compat.h"
     #include "zeek-spicy/plugin/plugin.h"
+    #include "zeek-spicy/autogen/config.h"
+
 %%}
 
 function Spicy::__toggle_analyzer%(tag: any, enable: bool%) : bool
@@ -18,4 +20,8 @@ function Spicy::__toggle_analyzer%(tag: any, enable: bool%) : bool
             zeek::reporter->Warning("could not toggle Spicy analyzer");
 
         return ::zeek::val_mgr->Bool(result);
+        %}
+function Spicy::version%(%) : count
+        %{
+            return ::zeek::val_mgr->Count(SPICY_VERSION_NUMBER);
         %}


### PR DESCRIPTION
The idea is to enable conditional-on-spicy-version code at runtime in script-land.

Very much WIP. Tests will follow if this make sense (will open issue shortly).