### PR TITLE
Fix backport of change to how exceptions are reported

### DIFF
--- a/src/file-analyzer.cc
+++ b/src/file-analyzer.cc
@@ -100,6 +100,12 @@ bool FileAnalyzer::Process(int len, const u_char* data) {
         STATE_DEBUG_MSG(hilti::rt::fmt("parse error, triggering analyzer violation: %s", e.what()));
         auto tag = OurPlugin->tagForFileAnalyzer(_state.cookie().analyzer->Tag());
         spicy::zeek::compat::Analyzer_AnalyzerViolation(_state.cookie().analyzer, e.what(), nullptr, 0, tag);
+    } catch ( const hilti::rt::RecoverableFailure& e ) {
+        // Spicy changed the exception hierarchy between 1.5 and 1.7 so that `RecoverableFailure`
+        // is a `ParseError` as well. Explicitly handle it for earlier versions.
+        STATE_DEBUG_MSG(hilti::rt::fmt("parse error, triggering analyzer violation: %s", e.what()));
+        auto tag = OurPlugin->tagForFileAnalyzer(_state.cookie().analyzer->Tag());
+        spicy::zeek::compat::Analyzer_AnalyzerViolation(_state.cookie().analyzer, e.what(), nullptr, 0, tag);
     } catch ( const hilti::rt::Exception& e ) {
         STATE_DEBUG_MSG(e.what());
         reporter::analyzerError(_state.cookie().analyzer, e.description(),
@@ -114,6 +120,12 @@ void FileAnalyzer::Finish() {
         hilti::rt::context::CookieSetter _(&_state.cookie());
         _state.finish();
     } catch ( const spicy::rt::ParseError& e ) {
+        STATE_DEBUG_MSG(hilti::rt::fmt("parse error, triggering analyzer violation: %s", e.what()));
+        auto tag = OurPlugin->tagForFileAnalyzer(_state.cookie().analyzer->Tag());
+        spicy::zeek::compat::Analyzer_AnalyzerViolation(_state.cookie().analyzer, e.what(), nullptr, 0, tag);
+    } catch ( const hilti::rt::RecoverableFailure& e ) {
+        // Spicy changed the exception hierarchy between 1.5 and 1.7 so that `RecoverableFailure`
+        // is a `ParseError` as well. Explicitly handle it for earlier versions.
         STATE_DEBUG_MSG(hilti::rt::fmt("parse error, triggering analyzer violation: %s", e.what()));
         auto tag = OurPlugin->tagForFileAnalyzer(_state.cookie().analyzer->Tag());
         spicy::zeek::compat::Analyzer_AnalyzerViolation(_state.cookie().analyzer, e.what(), nullptr, 0, tag);


### PR DESCRIPTION
47e1e95cb149fb48a4a56473dc51ffeadcc1442b changed how parse errors are reported to Zeek. In backporting this change we missed that the changes depended on the Spicy-side exception, namely that a `RecoverableFailure` was a `ParseError`. This is not the case for older Spicy versions.

This patch fixes the backport so we handle `RecoverableFailure` exceptions as well. This prevents exception escape from that.

Closes #195.